### PR TITLE
Fixed callback_url for the callback_phase

### DIFF
--- a/lib/omniauth/strategies/pipedrive.rb
+++ b/lib/omniauth/strategies/pipedrive.rb
@@ -17,6 +17,10 @@ module OmniAuth
         super
       end
 
+      def callback_url
+        options[:redirect_uri] || (full_host + script_name + callback_path)
+      end
+
       uid { raw_info['id'].to_s }
 
       info do


### PR DESCRIPTION
The `redirect_uri` that gets passed to Pipedrive in the callback phase, should _not_ contain the query string of the URL that Pipedrive redirected to upon completion of the request phase.