### PR TITLE
updated omniauth to version 2

### DIFF
--- a/omniauth-pipedrive.gemspec
+++ b/omniauth-pipedrive.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = OmniAuth::Pipedrive::VERSION
 
-  gem.add_dependency 'omniauth', '~> 1.0'
-  gem.add_dependency 'omniauth-oauth2', '~> 1.0'
+  gem.add_dependency 'omniauth', '~> 2.1'
+  gem.add_dependency 'omniauth-oauth2', '~> 1.8'
 
-  gem.add_development_dependency "bundler", "~> 1.0"
+  gem.add_development_dependency "bundler", "~> 2.0"
   gem.add_development_dependency "pry", '~> 0'
 end


### PR DESCRIPTION
The gem wasn't working anymore with the current pipedrive oauth integration. It is working perfectly with oauth v2